### PR TITLE
prevent cloud-init from managing hostname

### DIFF
--- a/ansible-data/roles/common/tasks/main.yml
+++ b/ansible-data/roles/common/tasks/main.yml
@@ -2,6 +2,12 @@
   hostname:
     name: "{{ hostname }}"
 
+- name: prevent cloud-init from reverting hostname
+  lineinfile:
+    dest: /etc/cloud/cloud.cfg
+    regexp: '^preserve_hostname:.*'
+    line: 'preserve_hostname: true'
+
 - block:
   - name: Update all packages to the latest version
     apt:


### PR DESCRIPTION
Avoid 2 cfgmgmt tools concurrently managing the same resource.

Changing the hostname after puppet's cert has been generated breaks puppet runs.

As an alternative, we could also uninstall cloud-init once ansible is up and running.