### PR TITLE
Add explicit dependencies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,20 @@ resource "puppetdb_node" "this" {
   count = var.instance_count
 
   certname = var.instances[count.index].hostname
+
+  depends_on = [
+    null_resource.provisioner
+  ]
 }
 
 resource "puppetca_certificate" "this" {
   count = var.instance_count
 
-
   name = var.instances[count.index].hostname
+
+  depends_on = [
+    null_resource.provisioner
+  ]
 }
 
 resource "null_resource" "provisioner" {


### PR DESCRIPTION
Without the explicit dependencies, the puppetca_certificate and puppetdb_node
resources are always created. These resources being checks that the
corresponding real resources have been created by Puppet, we have to wait for
their timeout to expire before being able to re-apply Terraform in case the
provisioner fails. By adding explicit dependencies, these resources will be
created only if the provisioner is successful which will solve the problem.