### PR TITLE
feat: add support for Debian Bullseye to ansible code

### DIFF
--- a/ansible-data/roles/common/tasks/main.yml
+++ b/ansible-data/roles/common/tasks/main.yml
@@ -15,6 +15,16 @@
   when: cloud_cfg.stat.exists == true
 
 - block:
+  - block:
+    - name: override ansible_python_interpreter on Bullseye
+      set_fact:
+        ansible_python_interpreter: /usr/bin/python3
+    - name: Install gpg package for apt-key
+      apt:
+        name: gpg
+        state: present
+    when: ansible_distribution_major_version == "11"
+
   - name: Update all packages to the latest version
     apt:
       upgrade: dist


### PR DESCRIPTION
The ansible_python_interpreter variable must be set to python3 on Bullseye
because python2 is still the default for that distribution, but it doesn't
support python-apt for pyhton2 anymore.

The gpg package must be installed because it is required by the apt-key
command.